### PR TITLE
Some good functionality so far

### DIFF
--- a/racket/rco2.rkt
+++ b/racket/rco2.rkt
@@ -5,6 +5,7 @@
 (define (make-let var val body)
   (list 'let (list [list var val]) body))
 
+
 (define not-empty? (λ (l) (not (empty? l))))
 ;test not empty
 (check-false (not-empty? '()))
@@ -21,7 +22,8 @@
      (error "rco-exp let case")]
     ; this case should call rco-arg on each of the args
     ; then build a new expr with bindings from the rco-arg calls
-    [(list op args ...) 
+    [(list op args ...)
+     (displayln (list "match-op-exprs" exprs))
      (define-values [syms alists]
        (for/lists (l1 l2) 
                 ([e exprs])
@@ -29,10 +31,14 @@
      (displayln (list "rco-exp syms " syms))
      (displayln (list "rco-exp alists " alists))
      ; loop over alists
-     (for/list ([pair alists]
-                [sym syms])
-       (match pair
+
+     ; generate the final expr by
+     (for/list ([binds alists] ; loop over both the binds
+                [sym syms])    ; and the corresponding syms
+       (match binds
+         ; match anything complex
          [(list var val) (make-let var val syms)]
+         ; match the op symbol for e.g.
          [_ sym]))]))
 
  ; Given an expr in R1, return a temp symbol name and an alist mapping from the symbol name to an expr in R1
@@ -44,7 +50,7 @@
     [(list 'let (list [list var val]) body) (error "rco-arg let case")]
     [(list op args ...) (let ([tmp-name (gensym 'tmp)])
                           (values tmp-name
-                                  (list tmp-name (rco-exp exprs))))]))
+                                  (list tmp-name exprs)))]))
 
 ; TEST HELPERS
 (define make-list-from-vals (λ (a b) (list a b)))
@@ -92,6 +98,8 @@
 ;(check-equal? (rco-exp (list 'read)) '(read))
 ;
 
+(displayln '(rco-exp '(+ (- 3) (- 4))))
+(displayln (rco-exp '(+ (- 3) (- 4))))
  
 
 (displayln "tests finished")

--- a/racket/rco2.rkt
+++ b/racket/rco2.rkt
@@ -58,7 +58,7 @@
     ; this case should call rco-arg on each of the args
     ; then build a new expr with bindings from the rco-arg calls
     ; + and - need pattern match 1 or more
-    [(or (list (? op? op) _ ..1) (list (? is-read? op)))
+    [(list (? op? op) _ ..1)
      (define-values [syms bindings]
        (for/lists (l1 l2) 
                 ([e exprs])
@@ -75,7 +75,7 @@
     ; TODO let case should bind var to val in an alist and evaluate the body somehow 
     [(list 'let (list [list var val]) body) exprs]
     ; + and - need pattern match 1 or more
-    [(or (list (? op? op) _ ..1))
+    [(list (? op? op) _ ..1)
          (let ([tmp-name (gensym 'tmp)])
                           (values tmp-name
                                   (list tmp-name exprs)))]

--- a/racket/rco2.rkt
+++ b/racket/rco2.rkt
@@ -76,7 +76,7 @@
     ; TODO let case should bind var to val in an alist and evaluate the body somehow 
     [(list 'let (list [list var val]) body) exprs]
     ; + and - need pattern match 1 or more
-    [(or (list (? op? op) _ ..1) (list (? is-read? op)))
+    [(or (list (? op? op) _ ..1))
          (let ([tmp-name (gensym 'tmp)])
                           (values tmp-name
                                   (list tmp-name exprs)))]


### PR DESCRIPTION
**CHANGES**
* simplified rco-arg to not call rco-exp anymore (this is on purpose so that the simple operation cases could be handled) (also a TODO: fix that to call rco-exp again)
* added a hashmap `(define OPS (hash '+ 1 '- 2 'read 3))` for acceptable operations
* added many test cases even some that correctly fail & get full code coverage
* completed all the match arms and added stricter pattern matching that fits R1


* added a helper function `make-nested-lets`

```racket
; recursively generate bindings
(define (make-nested-lets bindings body)
  (cond [(empty? bindings) body] ; base base case
        [else (match (first bindings)
                [(? empty?)
                 ; at this point bindings is not empty
                 ; but (first bindings) is empty
                 ; (rest bindings) is a perfectly safe call
                 ; due to the nature of pairs in Racket
                 ; i.e. keep recursing because there could be more bindings
                 (make-nested-lets (rest bindings) body)]
                [(list var val)
                 (make-let var val (make-nested-lets (rest bindings) body))]
                [_ (error "unexpected")])]))

; TEST make-nested-lets
(check-equal? (make-nested-lets (list (list 'tmp '(- 2))) 'body) '(let ((tmp (- 2))) body))
(check-equal? (make-nested-lets (list) 'body) 'body)
(check-fail (λ () (make-nested-lets (list 'foo 'bar) 'body)))
(check-equal? (make-nested-lets (list '() '(tmp (- 2))) 'body) '(let [[tmp (- 2)]] body))
; now a legit test case
(check-equal? (make-nested-lets (list '(tmp1 (+ 3 4)) '(tmp2 (- 2))) '(+ tmp1 tmp2))
              '(let [[tmp1 (+ 3 4)]]
                    (let [[tmp2 (- 2)]]
                         (+ tmp1 tmp2))))
```

**Some nice passing cases:**

```racket
> (displayln (rco-exp '(+ (- 3) 4)))
(let ((tmp129978 (- 3))) (+ tmp129978 4))
> (displayln  (rco-exp '(+ (- 3) (- 4))))
(let ((tmp130095 (- 3))) (let ((tmp130096 (- 4))) (+ tmp130095 tmp130096)))
> (displayln (rco-exp '(let ([x 2]) x)))
(let ((x 2)) x)
> 
```


**sadly some failing cases**

```racket
> (displayln (rco-exp '(+ 2 (- (+ 3 4)))))
(let ((tmp130631 (- (+ 3 4)))) (+ 2 tmp130631))
> (rco-exp '(+ (let [[x 3]] x) 4))
. . result arity mismatch;
 expected number of values not received
  expected: 2
  received: 1
  in: local-binding form
  values...:
> 
```