### PR TITLE
Maybe it works sort of??

### DIFF
--- a/racket/rco2.rkt
+++ b/racket/rco2.rkt
@@ -5,41 +5,55 @@
 (define (make-let var val body)
   (list 'let (list [list var val]) body))
 
-; Given an expr in R1, return an expr in R1 without any complex subexpressions
-(define (rco-exp exprs) ; returns expr
-  (match exprs
-    ; handle base cases
-    [(or (? symbol?) (? integer?) '(read)) exprs]
-    ; ??? in rust we add this binding to the alist but maybe that's not right...
-    [(list 'let (list [list var val]) body)
-     (displayln (list var val body)) 
-     (error "rco-exp let case")]
-    ; this case should call rco-arg on each of the args
-    ; then build a new expr with bindings from the rco-arg calls
-    [(list op args ...) 
-     (define-values [syms alists]
-       (for/lists (l1 l2) 
-                ([e exprs])
-       (rco-arg e)))
-     (displayln (list "rco-exp syms " syms))
-     (displayln (list "rco-exp alists " alists))
-     ; loop over alists
-     (for/list ([pair alists]
-                [sym syms])
-       (match pair
-         [(list var val) (make-let var val syms)]
-         [_ sym]))]))
+(define (create-all-bindings body binding-list)
+  42)
 
- ; Given an expr in R1, return a temp symbol name and an alist mapping from the symbol name to an expr in R1
-(define (rco-arg exprs) ; returns expr, alist
+; Given an expr in R1, return an expr in R1 without any complex subexpressions
+; Calls rco-exp on the input expression, which should recursively call rco-arg or rco-exp
+; rco gets a simple expression (one of (read), (- tmp), (+ tmp1 tmp2))) and an association
+; list with all the bindings that need to be created. The bindings MUST be ordered according
+; to scope (e.g., if tmp2 is bound to (- tmp1), then tmp2 must come BEFORE tmp1 in the alist).
+; rco then iterates through the alist and creates nested bindings, where the simple-expr is 
+; treated as the body of the binding. On each iteration, the body is updated to become the
+; newly created let-expression.
+(define (rco exprs) ; returns expr
+  (define-values [simple-expr alist] (rco-exp exprs))
+  (define not-empty (lambda (lst) (not (empty? lst))))
+  (define bindings-to-make (filter not-empty alist))
+  (create-all-bindings simple-expr bindings-to-make))
+
+; Given an expr in R1, return a simple expr in R1 and an association list
+(define (rco-exp exprs)
+  (match exprs
+    [(or (? symbol?) (? integer?) '(read)) (values exprs '())]
+    ; defer to rco-arg for let case
+    [(list 'let (list [list var val]) body) (rco-arg exprs)]
+    ; iterate through expression list and call rco-arg on each argument
+    [(list op args ...) 
+     (define-values [syms bindings]
+       (for/fold  ([syms '()]
+                   [bindings '()])
+                  ([e exprs]) 
+         (define-values [symbol alist] (rco-arg e))
+         (values (append syms (list symbol)) (append alist bindings))))
+     (values syms bindings)]))
+
+; Given an expr in R1, return a temp symbol name and an alist mapping from the symbol name to an expr in R1
+; returns expr, alist
+(define (rco-arg exprs)
   (match exprs
     ; handle simple base cases
     [(or (? symbol?) (? integer?) '(read)) (values exprs '())]
     ; TODO let case should bind var to val in an alist and evaluate the body somehow 
     [(list 'let (list [list var val]) body) (error "rco-arg let case")]
-    [(list op args ...) (let ([tmp-name (gensym 'tmp)])
-                          (values tmp-name
-                                  (list tmp-name (rco-exp exprs))))]))
+    [(list op args ...)
+     (define tmp-name (gensym 'tmp))
+     ; recursively call rco-exp on this expression 
+     (define-values [syms alist] (rco-exp exprs))
+     (values tmp-name
+             ; add the newest binding to the front of the list
+             ; TODO is this the correct ordering?
+             (append (list (list tmp-name syms)) alist))]))
 
 ; TEST HELPERS
 (define make-list-from-vals (λ (a b) (list a b)))
@@ -54,23 +68,28 @@
     (call-with-values (λ () (rco-arg given)) make-list-from-vals) 
     (list (? symbol? s) (list (? symbol? s) expect))))
 
+(rco-exp '(+ 2 2))
+(rco-exp '(+ 2 (- 3)))
+(rco-exp '(+ (- 2) 3))
+(rco-exp '(+ (- 2) (- 3)))
+(rco-exp '(+ (- (- 2)) 3))
 ; TEST CASES
 ; ATOMS should stay simple rco-exp
-(check-equal? (rco-exp 2) 2)
-(check-equal? (rco-exp '+) '+)
-; ATOMS should stay simple rco-arg
-(verify-rco-arg-output-is-empty 2)
-(verify-rco-arg-output-is-empty '+)
-
-
-; OPERATIONS should get simplied by rco-arg
-(verify-rco-arg-output '(+ 2 2) '(+ 2 2))
-
-; SIMPLE OPERATIONS should stay simple when called by rco-exp
-(check-equal? (rco-exp '(+ 2 2)) '(+ 2 2))
-
-(displayln "yes")
-(rco-exp '(+ 2 (- (+ 3 4))))
+;(check-equal? (rco-exp 2) 2)
+;(check-equal? (rco-exp '+) '+)
+;; ATOMS should stay simple rco-arg
+;(verify-rco-arg-output-is-empty 2)
+;(verify-rco-arg-output-is-empty '+)
+;
+;
+;; OPERATIONS should get simplied by rco-arg
+;(verify-rco-arg-output '(+ 2 2) '(+ 2 2))
+;
+;; SIMPLE OPERATIONS should stay simple when called by rco-exp
+;(check-equal? (rco-exp '(+ 2 2)) '(+ 2 2))
+;
+;(displayln "yes")
+;(rco-exp '(+ 2 (- (+ 3 4))))
 ;(rco-arg '(let ([x 1]) x))
 ;
 ;; BAD exprs rco-exp

--- a/racket/rco2.rkt
+++ b/racket/rco2.rkt
@@ -8,7 +8,7 @@
 (define (create-all-bindings body binding-list)
   (for/fold ([final-expr body])
             ([binding binding-list])
-    (make-let (first binding) (rest binding) final-expr)))
+    (make-let (first binding) (first (rest binding)) final-expr)))
 
 ; Given an expr in R1, return an expr in R1 without any complex subexpressions
 ; Calls rco-exp on the input expression, which should recursively call rco-arg or rco-exp
@@ -37,7 +37,8 @@
                    [bindings '()])
                   ([e exprs]) 
          (define-values [symbol alist] (rco-arg e))
-         (values (append syms (list symbol)) (append alist bindings))))
+         (values (append syms (list symbol))
+                 (append alist bindings))))
      (values syms bindings)]))
 
 ; Given an expr in R1, return a temp symbol name and an alist mapping from the symbol name to an expr in R1
@@ -86,16 +87,6 @@
     (call-with-values (λ () (rco-arg given)) make-list-from-vals) 
     (list (? symbol? s) (list (? symbol? s) expect))))
 
-(rco-exp '(+ 2 2))
-(rco-exp '(+ 2 (- 3)))
-(rco-exp '(+ (- 2) 3))
-(rco-exp '(+ (- 2) (- 3)))
-(rco-exp '(+ (- (- 2)) 3))
-(rco-exp '(+ (- (- 2)) (+ 3 (- 4))))
-(rco-exp '(let ([x 1]) x))
-(rco-exp '(+ (let ([x 1]) x)))
-(rco-exp '(+ (let ([x (- (- 1))]) (+ x (- 2))) 40))
-
 (rco '(+ 2 2))
 (rco '(+ 2 (- 3)))
 (rco '(+ (- 2) 3))
@@ -103,8 +94,13 @@
 (rco '(+ (- (- 2)) 3))
 (rco '(+ (- (- 2)) (+ 3 (- 4))))
 (rco '(let ([x 1]) x))
-(rco '(+ (let ([x 1]) x)))
+(rco '(+ 4 (let ([x 1]) x)))
 (rco '(+ (let ([x (- (- 1))]) (+ x (- 2))) 40))
+(rco '(let ([a 42]) (let ([b a]) b)))
+(rco '(let ([y (let ([x 20]) x)]) (+ y 1)))
+
+; this was the test case we were failing before in rust
+(rco '(let ([y (let ([x1 20]) (+ x1 (let ([x2 22]) x2)))]) y))
 
 
 ; TEST CASES

--- a/racket/rco2.rkt
+++ b/racket/rco2.rkt
@@ -6,7 +6,9 @@
   (list 'let (list [list var val]) body))
 
 (define (create-all-bindings body binding-list)
-  42)
+  (for/fold ([final-expr body])
+            ([binding binding-list])
+    (make-let (first binding) (rest binding) final-expr)))
 
 ; Given an expr in R1, return an expr in R1 without any complex subexpressions
 ; Calls rco-exp on the input expression, which should recursively call rco-arg or rco-exp
@@ -16,7 +18,7 @@
 ; rco then iterates through the alist and creates nested bindings, where the simple-expr is 
 ; treated as the body of the binding. On each iteration, the body is updated to become the
 ; newly created let-expression.
-(define (rco exprs) ; returns expr
+(define (rco exprs)
   (define-values [simple-expr alist] (rco-exp exprs))
   (define not-empty (lambda (lst) (not (empty? lst))))
   (define bindings-to-make (filter not-empty alist))
@@ -93,6 +95,18 @@
 (rco-exp '(let ([x 1]) x))
 (rco-exp '(+ (let ([x 1]) x)))
 (rco-exp '(+ (let ([x (- (- 1))]) (+ x (- 2))) 40))
+
+(rco '(+ 2 2))
+(rco '(+ 2 (- 3)))
+(rco '(+ (- 2) 3))
+(rco '(+ (- 2) (- 3)))
+(rco '(+ (- (- 2)) 3))
+(rco '(+ (- (- 2)) (+ 3 (- 4))))
+(rco '(let ([x 1]) x))
+(rco '(+ (let ([x 1]) x)))
+(rco '(+ (let ([x (- (- 1))]) (+ x (- 2))) 40))
+
+
 ; TEST CASES
 ; ATOMS should stay simple rco-exp
 ;(check-equal? (rco-exp 2) 2)


### PR DESCRIPTION
- Rewrote `rco-exp` and `rco-arg` to return both an expr and an alist, and have a top level function(`rco`) that calls `rco-exp` on the input expression, gets the alist from `rco-exp` and creates all the bindings from the alist it receives
- Have some "test cases" that just run and I inspected the output by eye. It looks right(-ish) to me - sometimes it inserts unnecessary temps but otherwise it seems ok (including the two test cases from the book/the nested-let test case we were failing in Rust)

This is basically the approach we used in the Rust version. `rco-exp` and `rco-arg` only create alists - they NEVER create bindings - bindings are handled entirely by the top-level `rco` function. `rco-exp` and `rco-arg` are careful to generate an alist such that bindings that rely on other bound variables come BEFORE the variables that they rely on. This is because `rco` creates bindings from the bottom up, and bindings must be defined after their dependencies to be valid.

The reason for this approach is that I found `let` statements nested in the value of other `let` statements confusing to reason about. By leaving the creation of bindings all the way to the end, (I think) this approach ensures that, after this pass, `let` statements can only occur in the body of other `let` statements.

## Some passing cases
```racket
(rco '(+ 2 (- 3)))  
'(let ((tmp239 (- 3))) (+ 2 tmp239))

(rco '(+ 4 (let ([x 1]) x))) 
'(let ((x 1)) (+ 4 x))

(rco '(+ (let ([x (- (- 1))]) (+ x (- 2))) 40))
'(let ((tmp251 (- 1))) (let ((x (- tmp251))) (let ((tmp250 (- 2))) (let ((tmp249 (+ x tmp250))) (+ tmp249 40)))))

(rco '(let ([a 42]) (let ([b a]) b)))
'(let ((a 42)) (let ((b a)) b))

(rco '(let ([y (let ([x 20]) x)]) (+ y 1))) 
'(let ((x 20)) (let ((y x)) (let ((tmp252 (+ y 1))) tmp252)))

; the failing test case from Rust
; not exactly right - it still inserts an unneeded temporary variable for y
(rco '(let ([y (let ([x1 20]) (+ x1 (let ([x2 22]) x2)))]) y))
'(let ((x1 20)) (let ((x2 22)) (let ((tmp253 (+ x1 x2))) (let ((y tmp253)) y))))
```

## TODO
- [x] Fix merge conflicts
- [ ] Write tests