### PR TITLE
Select instructions tested and completed

### DIFF
--- a/racket/select-instructions.rkt
+++ b/racket/select-instructions.rkt
@@ -1,12 +1,14 @@
 #!/usr/bin/racket
 #lang racket
-(require rackunit)
+(require rackunit) ; for check-?? funcs
+(require racket/exn) ; for exn->string
+(require "test-helpers.rkt") ; for check-fail and check-fail-with-name
 
 (define (select-instructions c0-prog)
   (match c0-prog
     [`(program ,locals (,label ,tail)) 
       `(program ,locals (,label (,handle-tail ,tail)))]
-    [_ (error 'select-instructions "bad c0-prog:" c0-prog)]))
+    [_ (error 'select-instructions "bad c0-prog: ~v" c0-prog)]))
 
 
 ; Given a C0 arg (int or var), emit an x86_0 arg (int 2) or (reg register)
@@ -14,54 +16,126 @@
   (match arg
     ; TODO do fixnum everywhere!
     [(? fixnum? n) `(int ,n)]
-    [(? symbol? s) `(var ,s)]))
+    [(? symbol? s) `(var ,s)]
+    [_ (if (number? arg)
+           (error 'handle-arg "bad num: ~v" arg)
+           (error 'handle-arg "bad arg: ~v" arg))]))
 
 ; Given a C0 statement (assign), emit an x86_0 instruction (movq or addq or negq)
 (define (handle-stmt stmt)
-  (match stmt
-    [`(assign ,(? symbol? lhs) (read))
-      `((callq read_int)
-        (movq (reg rax) (var ,lhs)))]
-    [`(assign ,(? symbol? lhs) (+ ,args ..2)) 
-      (define x86-var (handle-arg lhs))
-      `((movq ,(handle-arg (first args)) ,x86-var)
-        (addq ,(handle-arg (second args)) ,x86-var))]
-    [`(assign ,(? symbol? lhs) (- ,arg)) 
-      (define x86-var (handle-arg lhs))
-      `((movq ,(handle-arg arg) ,x86-var) 
-        (negq ,x86-var))]
-    [`(assign ,(? symbol? lhs) ,val) `(movq ,(handle-arg val) ,(handle-arg lhs))]
-    [_ (error "plsno")]))
+  (with-handlers ([exn:fail? (λ (exn) (error 'handle-stmt (exn->string exn)))])
+    (match stmt
+      [`(assign ,(? symbol? lhs) (read))
+       `((callq read_int)
+         (movq (reg rax) (var ,lhs)))]
+      [`(assign ,(? symbol? lhs) (+ ,args ..2)) 
+       (define x86-var (handle-arg lhs))
+       `((movq ,(handle-arg (first args)) ,x86-var)
+         (addq ,(handle-arg (second args)) ,x86-var))]
+      [`(assign ,(? symbol? lhs) (- ,arg)) 
+       (define x86-var (handle-arg lhs))
+       `((movq ,(handle-arg arg) ,x86-var) 
+         (negq ,x86-var))]
+      [`(assign ,(? symbol? lhs) ,val) `(movq ,(handle-arg val) ,(handle-arg lhs))]
+      [_ (error 'handle-stmt "bad stmt: ~v" stmt)])))
 
 
 ; Given a C0 tail (sequence or return), call handle-stmt on statement and itself(?) on tail
 (define (handle-tail tail)
-  (match tail
-    [`(return ,expr) 
-      ; see pg 22 of textbook
-      `((movq ,(handle-arg expr) (reg rax))
-        (jmp conclusion))]
-    [`(seq ,stmt ,new-tail) 
-      ; handle the stmt and recursively call handle-tail on the tail
-      (define new-stmt-instr (handle-stmt stmt))
-      (define new-tail-instr (handle-tail new-tail))
-      (cons new-stmt-instr new-tail-instr)]
-    [_ (error 'handle-tail "bad tail:" tail)]))
+  (with-handlers ([exn:fail? (λ (exn) (error 'handle-tail (exn->string exn)))])
+    (match tail
+      [`(return ,expr) 
+       ; see pg 22 of textbook
+       `((movq ,(handle-arg expr) (reg rax))
+         (jmp conclusion))]
+      [`(seq ,stmt ,new-tail) 
+       ; handle the stmt and recursively call handle-tail on the tail
+       (define new-stmt-instr (handle-stmt stmt))
+       (define new-tail-instr (handle-tail new-tail))
+       (cons new-stmt-instr new-tail-instr)]
+      [_ (error 'handle-tail "bad tail:" tail)])))
+
+; ******************************
+; TEST handle-tail
+; ******************************
+; a simple seq tail
+(define given1 `(seq (assign x 2) (return x)))
+(check-equal? (handle-tail given1)
+                '((movq (int 2) (var x))
+                  (movq (var x) (reg rax))
+                  (jmp conclusion)))
+
+; a bad tail
+(check-fail (λ () (handle-tail 'foo)))
 
 
-(check-equal? (handle-tail `(seq (assign x 2) (return x)))
-                '((movq (int 2) (var x)) (movq (var x) (reg rax)) (jmp conclusion)))
+; a weirdly bad tail that assigns int to int
+(define given_bad_assign_tail '(seq (assign 42 23) (return x)))
+(check-fail (λ () (handle-tail given_bad_assign_tail)))
+(check-fail-with-name 'handle-tail handle-tail given_bad_assign_tail)
 
-(define given1 '((movq (int 32) (var x)) (addq (int 32) (var x))))
+; a simple return tail with var
+(define given_return_with_var `(return x))
+(check-equal? (handle-tail given_return_with_var)
+                '((movq (var x) (reg rax))
+                  (jmp conclusion)))
 
+; a simple return tail with int
+(define given_return_with_int `(return 42))
+(check-equal? (handle-tail given_return_with_int)
+                '((movq (int 42) (reg rax))
+                  (jmp conclusion)))
+
+; ******************************
+; TEST handle-stmt
+; ******************************
+; an assign to plus
 (define given2 '(assign x (+ 10 x)))
 (check-equal? (handle-stmt given2) `((movq (int 10) (var x)) (addq (var x) (var x))))
 
+; an assign to read 
 (define given3 '(assign x (read)))
 (check-equal? (handle-stmt given3) `((callq read_int) (movq (reg rax) (var x))))
 
+; an assign to negation
 (define given4 '(assign x (- y)))
 (check-equal? (handle-stmt given4) `((movq (var y) (var x)) (negq (var x))))
 
+; an assign to fixnum
 (define given5 '(assign x 5))
 (check-equal? (handle-stmt given5) `(movq (int 5) (var x)))
+
+; an assign to fixnum out of fixnum bounds
+(define BIG_NUM 9999999999999999999999999999999999)
+(define given6 `(assign x ,BIG_NUM))
+; make sure that the with-handler appends 'handle-stmt to the error
+(check-fail-with-name 'handle-stmt handle-stmt given6)
+
+; a bad stmt
+(define given7 'give_bad_stmt)
+(check-fail-with-name 'handle-stmt handle-stmt given7)
+
+; ******************************
+; TEST handle-tail
+; ******************************
+; a bad arg
+(define given8 #t)
+(check-fail-with-name 'handle-arg handle-arg given8)
+
+; an good fixnum
+(define given9 42)
+(check-equal? (handle-arg given9) '(int 42))
+
+; a bad fixnum
+(define BIG_BIG_NUM 999999999999999999999999999999999999999999999)
+(define given10 BIG_BIG_NUM)
+; make sure 'handle-arg fails gracefully with its own name
+(check-fail-with-name 'handle-arg handle-arg given10)
+
+; a good symbol
+(define given11 'variable)
+(check-equal? (handle-arg given11) `(var ,given11))
+
+; another bad arg
+(define given12 handle-arg) ; the #<procedure:handle-arg> itself
+(check-fail-with-name 'handle-arg handle-arg given12)

--- a/racket/test-helpers.rkt
+++ b/racket/test-helpers.rkt
@@ -1,0 +1,43 @@
+#!/usr/bin/racket
+#lang racket
+(require rackunit)
+(provide check-fail check-fail-with-name)
+
+; https://docs.racket-lang.org/rackunit/api.html#%28def._%28%28lib._rackunit%2Fmain..rkt%29._check-exn%29%29
+; given a thunk/lambda/procedure/funciton... make sure it fails
+(define (check-fail thunk) (check-exn exn:fail? thunk))
+
+; test check-fail
+(check-true (void? (check-fail (λ () (error)))))
+
+
+; setup namespace for eval
+; https://stackoverflow.com/a/37246112
+(current-namespace (make-base-namespace))
+
+; given the symbol name of a function
+; and the given_arg to pass into the function
+; make sure it fails and the error message contains the fun_name
+(define (check-fail-with-name fun_name fun_proc given_arg)
+  (cond [(symbol? fun_name)
+         (define regex_str (string-append (symbol->string fun_name) ".*"))
+         (check-exn (regexp regex_str) (λ () (fun_proc given_arg)))]
+        [else
+         (error 'check-fail-with-name "bad fun_name: ~v" fun_name)]))
+; test check-fail-with-name
+(check-true (void? (check-fail-with-name 'error error 'error)))
+
+; test bad args
+(check-fail (λ () (check-fail-with-name 32 42)))
+
+; test it catches diff name failure
+(define fn_err_with_diff_name (λ (bar) (error 'foo "wow ~v" bar)))
+(check-fail (λ () (fn_err_with_diff_name 'foo))) ; make sure it err by itself
+(define thunk (λ () (check-fail-with-name 'fn_err_with_diff_name fn_err_with_diff_name "given_arg")))
+(check-true (void? (check-fail thunk))) ; test case
+
+; test it catches allows same name failure
+(define fn_err_same_name (λ (bar) (error 'fn_err_same_name "wow ~v" bar)))
+(check-fail (λ () (fn_err_same_name 'foo))) ; make sure it err by itself
+(define res (check-fail-with-name 'fn_err_same_name fn_err_same_name 'foo))
+(check-true (void? res)) ; test case


### PR DESCRIPTION
**CHANGES**
* select-instructions seems to be fully implemented (would appreciate a review/confirmation of this)
* select-instructions has more tests and passes all of them
* there exists a new "test-helpers.rkt"
* select-instructions imports "test-helpers.rkt" via the line `(require "test-helpers.rkt)` combined with the line `(provide check-fail check-fail-with-name)` within "test-helpers.rkt"
* added some fancy exception handling syntax called `with-handlers` after [reading this blog post](https://beautifulracket.com/explainer/errors-and-exceptions.html)
  * the purpose is to have the errors propagate up the call stack from the helper functions (e.g. handle-tail) while still maintaining that the top-level function applies its own name in the error message. Thus allowing for a nice error message as seen below.

**How the code looks** _notice the with-handlers thing_
```
; given a C0 program, return a pseudo-x86_0 program
(define (select-instructions c0-prog)
  (with-handlers ([exn:fail? (λ (exn) (error 'select-instructions (exn->string exn)))])
    (match c0-prog
      [`(program ,locals (,label ,tail)) 
       `(program ,locals (,label ,(handle-tail tail)))]
      [_ (error 'select-instructions "bad c0-prog: ~v" c0-prog)])))
```

**How the error looks**  _notice how the error message on the last line shows the path of error messages_ Perhaps a bit ugly. Might be nice to reformat it. 
```
Welcome to DrRacket, version 7.3 [3m].
Language: racket, with test coverage [custom]; memory limit: 128 MB.
> ; test error message passing
(displayln given_bad_prog_4)
(program () (start (seq (assign 42 23) (return 0))))
> (select-instructions given_bad_prog_4)
. . select-instructions: handle-tail: handle-stmt: handle-stmt: bad stmt: (list 'assign 42 23)



> 
```