### PR TITLE
Correctly move variables in generated asm

### DIFF
--- a/racket/compiler.rkt
+++ b/racket/compiler.rkt
@@ -37,5 +37,14 @@
 ;   addq $2, %rax
 ;   retq
 ;(displayln (explicate-control (rco-prog (uniquify input1))))
-;(displayln (select-instructions (explicate-control (rco-prog input2))))
-(displayln (compile input2))
+(displayln (compile input-broken))
+
+;(define uniquified (uniquify input2))
+;(define rcod (rco-prog uniquified))
+;(define ecd (explicate-control rcod))
+;(define locals-uncovered (uncover-locals ecd))
+;(define instr-selected (select-instructions locals-uncovered))
+;(define homes-assigned (assign-homes instr-selected))
+;(displayln homes-assigned)
+;(define instructions-patched (patch-instructions homes-assigned))
+;(displayln instructions-patched)

--- a/racket/patch-instructions.rkt
+++ b/racket/patch-instructions.rkt
@@ -10,7 +10,7 @@
 ; into 
 ;               mov (deref rbp v1) (reg rax)
 ;               op (deref rbp v2) (reg rax)
-;               mov (reg rax) (deref rbp v1)
+;               mov (reg rax) (deref rbp v2)
 ;
 ; TODO There's a potential OPTIMIZATION here, e.g.:
 ;     addq (deref rbp -8) (deref rbp -16)
@@ -66,7 +66,7 @@
      ;LIST OF INSTRS???
      `((movq (deref rbp ,offset1) (reg rax))
       (addq (deref rbp ,offset2) (reg rax))
-      (movq (reg rax) (deref rbp ,offset1)))]
+      (movq (reg rax) (deref rbp ,offset2)))]
     [_ `(,instrs)]))
 
 


### PR DESCRIPTION
Should fix #10.
  
We were moving to the wrong variable home after patching an `addq` instruction.

On master, we were changing `addq (deref rbp v1) (deref rbp v2)` to:
```
mov (deref rbp v1) (reg rax)
addq (deref rbp v2) (reg rax)
mov (reg rax) (deref rbp v1)   ; should be moved to v2
```

Run `./build.sh` on one of the two inputs in `compiler.rkt` (both inputs are broken on `master`) and the output should now be correct.