### PR TITLE
Fix select instructions

### DIFF
--- a/racket/assign-homes.rkt
+++ b/racket/assign-homes.rkt
@@ -44,6 +44,9 @@
       [`(,op (var ,v)) `(,op (deref rbp ,(lookup-offset assns v)))]
       [`(callq ,label) i]
       [`(jmp ,label) i]
+      ; if we get an instruction that has no vars, then just return that instruction
+      ; ie, movq (int 1) (reg rax) should return itself
+      [`(,op ,any1 ,any2) i]
       ; TODO failing here - doesn't handle register case
       [_ (error 'assign-home-instrs "wat? ~s" i)])))
 
@@ -67,4 +70,7 @@
                                 (jmp conclusion)))))
 
 
+; test case for instructions that do not use any vars
+(define given2 '(program () (main ((movq (int 42) (reg rax))))))
+(check-equal? (assign-homes given2) given2)
 

--- a/racket/assign-homes.rkt
+++ b/racket/assign-homes.rkt
@@ -44,6 +44,7 @@
       [`(,op (var ,v)) `(,op (deref rbp ,(lookup-offset assns v)))]
       [`(callq ,label) i]
       [`(jmp ,label) i]
+      ; TODO failing here - doesn't handle register case
       [_ (error 'assign-home-instrs "wat? ~s" i)])))
 
 

--- a/racket/compiler.rkt
+++ b/racket/compiler.rkt
@@ -29,6 +29,7 @@
   '(program () (main 
                  (let ([x (+ 3 (+ 1 2))]) x))))
 
+(define input3 '(program () (main (+ 2 2))))
 
 ; expect: 
 ; .global main
@@ -38,4 +39,4 @@
 ;   retq
 ;(displayln (explicate-control (rco-prog (uniquify input1))))
 ;(displayln (select-instructions (explicate-control (rco-prog input2))))
-(displayln (compile input2))
+(displayln (compile input3))

--- a/racket/select-instructions.rkt
+++ b/racket/select-instructions.rkt
@@ -16,44 +16,48 @@
            (error 'handle-arg "bad num: ~v" arg)
            (error 'handle-arg "bad arg: ~v" arg))]))
 
+; Given a C0 expr [(+ 2 2), (- 3), (read)] and an output location (either (reg ...) or (var ...)
+; return a list of instructions that puts the output of the expr into the specified location
+(define (handle-expr expr output)
+  ; TODO error check output to make sure it's either a var or reg
+  (match expr
+    [`(read)
+      (if (eq? output '(reg rax))
+        `((callq read_int))
+        `((callq read_int) (movq (reg rax) ,output)))] 
+    [`(+ ,args ..2) 
+      `((movq ,(handle-arg (first args)) ,output)
+        (addq ,(handle-arg (second args)) ,output))]
+    [`(- ,arg)
+      `((movq ,(handle-arg arg) ,output)
+        (negq ,output))]
+    ; if it isn't a list, assume it's a var, which only requires a mov instruction
+    [(? (lambda (x) (not (list? x))) var) 
+     `((movq ,(handle-arg var) ,output))]
+    [_ (error "handle-expr failed on expression")]))
+
 ; Given a C0 statement (assign), emit an x86_0 instruction (movq or addq or negq)
 (define (handle-stmt stmt)
   (with-handlers ([exn:fail? (λ (exn) (error 'handle-stmt (exn->string exn)))])
     (match stmt
-      [`(assign ,(? symbol? lhs) (read))
-       `((callq read_int)
-         (movq (reg rax) (var ,lhs)))]
-      [`(assign ,(? symbol? lhs) (+ ,args ..2))
-       (define x86-var (handle-arg lhs))
-       `((movq ,(handle-arg (first args)) ,x86-var)
-         (addq ,(handle-arg (second args)) ,x86-var))]
-      [`(assign ,(? symbol? lhs) (- ,arg))
-       (define x86-var (handle-arg lhs))
-       `((movq ,(handle-arg arg) ,x86-var)
-         (negq ,x86-var))]
-      [`(assign ,(? symbol? lhs) ,val) `((movq ,(handle-arg val) ,(handle-arg lhs)))]
+      ; if it's third element in stmt is a list, it must be an expr
+      [`(assign ,(? symbol? lhs) ,expr)
+        (define output (handle-arg lhs))
+        (handle-expr expr output)]
       [_ (error 'handle-stmt "bad stmt: ~v" stmt)])))
-
 
 ; Given a C0 tail (sequence or return), call handle-stmt on statement and itself(?) on tail
 (define (handle-tail tail)
   (with-handlers ([exn:fail? (λ (exn) (error 'handle-tail (exn->string exn)))])
     (match tail
-      ;[`(return (+ ,a1 ,a2))
-      ;  
-      ;  ]
       [`(return ,expr)
-       ; see pg 22 of textbook
-       `((movq ,(handle-arg expr) (reg rax))
-         (jmp conclusion))]
+       (append (handle-expr expr '(reg rax)) '((jmp conclusion)))]
       [`(seq ,stmt ,new-tail)
        ; handle the stmt and recursively call handle-tail on the tail
        (define new-stmt-instr (handle-stmt stmt))
        (define new-tail-instr (handle-tail new-tail))
        (append new-stmt-instr new-tail-instr)]
       [_ (error 'handle-tail "bad tail:" tail)])))
-
-
 
 ;(define given_ret_plus_2_2  '(return (+ 2 2)) )
 ;(define expect_ret_plus_2_2 '(movq )  )


### PR DESCRIPTION
# Description
- Added function `handle-expr` to `select-instructions` that is general enough to work with both vars and registers. This lets us translate C0 return statements more easily.
- Updated `assign-homes` to handle the case where we have an instruction that doesn't reference any variables (e.g. `movq (int 1) (reg rax)`), which we'll now see from return statements in C0.
- Added a single test case to `assign-homes` that is just a program with an instruction that doesn't use any vars.

See #9 