### PR TITLE
Refactor uniquify.rkt / rco.rkt / ec.rkt

### DIFF
--- a/racket/compiler.rkt
+++ b/racket/compiler.rkt
@@ -22,12 +22,10 @@
 
 
 (define input-broken
-  '(program () (main 
-                 (let ([x (+ 3 (+ 1 2))]) (+ x (- 1))))))
+  '(program () (let ([x (+ 3 (+ 1 2))]) (+ x (- 1)))))
 
 (define input2
-  '(program () (main 
-                 (let ([x (+ 3 (+ 1 2))]) x))))
+  '(program () (let ([x (+ 3 (+ 1 2))]) x)))
 
 
 ; expect: 

--- a/racket/rco.rkt
+++ b/racket/rco.rkt
@@ -189,6 +189,10 @@
 (check-fail (λ () (rco-prog '(program () (start (+ 2 2))))))
 
 
-; TEST rco-prog
+; TEST rco-prog simple 
 (check-equal? (rco-prog '(program () (+ 2 2)))
                 '(program () (+ 2 2)))
+
+; TEST rco-prog complex
+(check-match (rco-prog '(program () (+ (- 1) 2)))
+                `(program () (let [[,(? symbol? tmp) (- 1)]] (+ ,tmp 2))))

--- a/racket/rco.rkt
+++ b/racket/rco.rkt
@@ -174,17 +174,17 @@
 
 
 ; testing rco-prog
-(define given3-prog `(program () (start ,given3)))
+(define given3-prog `(program () ,given3))
 (check-match (rco-prog given3-prog)
-             `(program () (start (let ([,(? symbol? neg1) (- 1)]) 
+             `(program () (let ([,(? symbol? neg1) (- 1)]) 
                                     (let ([x (- ,neg1)]) 
                                       (let [[,(? symbol? neg2) (- 2)]] 
-                                        (let [[,(? symbol? plusxneg2) (+ x ,neg2)]] (+ ,plusxneg2 40))))))))
+                                        (let [[,(? symbol? plusxneg2) (+ x ,neg2)]] (+ ,plusxneg2 40)))))))
 
 
 ; test bad rco-prog inputs
 (check-fail (λ () (rco-prog #t)))
-(check-fail (λ () (rco-prog (λ () 42))))
+(check-fail (λ () (rco-prog rco-prog)))
 ; R1 does not have labels
 (check-fail (λ () (rco-prog '(program () (start (+ 2 2))))))
 

--- a/racket/uniquify.rkt
+++ b/racket/uniquify.rkt
@@ -55,8 +55,8 @@
 (define (uniquify e)
   (match e
     [`(program ,info (,label ,e))
-     `(program ,info (,label ,((uniquify-exp '()) e)))]
-    [_ (error "Malformed program given to uniquify: ~s" e)]))
+     `(program ,info (,label ,(uniquify-exp e '())))]
+    [_ (error 'uniquify "Malformed program: ~s" e)]))
 
 (define given1 '(+ 2 2))
 (define expect1 '(+ 2 2))

--- a/racket/uniquify.rkt
+++ b/racket/uniquify.rkt
@@ -50,7 +50,7 @@
      `(let ([,new-var ,uniquified-val]) ,uniquified-body)]
     [`(,op ,es ...)
      `(,op ,@(for/list ([e es]) (uniquify-exp e alist)))]
-    [_ (error "Malformed expression given to uniquify-exp: ~s" e)]))
+    [_ (error 'uniquify-exp "Malformed expression: ~s" e)]))
 
 (define (uniquify e)
   (match e
@@ -69,7 +69,7 @@
 
 (define given3 '(let ([x 1]) (let ([x x]) (+ x x))))
 (check-match (uniquify-exp given3 '())
-              `(let ([,(? symbol? s1) 1]) 
+              `(let ([,(? symbol? s1) 1])
                  (let ([,(? symbol? s2) ,s1])
                    (+ ,s2 ,s2))))
 
@@ -79,3 +79,13 @@
 
 (define given5 '(let ([x 5]) (+ y 3)))
 (check-fail (lambda () (uniquify-exp given5 '())))
+
+; test bad uniquify-exp inputs
+(check-fail (λ () (uniquify-exp #t '())))
+(check-fail (λ () (uniquify-exp uniquify-exp '())))
+
+; test bad uniquify inputs
+(check-fail (λ () (uniquify #t)))
+(check-fail (λ () (uniquify uniquify-exp)))
+; R1 does not have labels
+(check-fail (λ () (uniquify '(program () (start (+ 2 2))))))

--- a/racket/uniquify.rkt
+++ b/racket/uniquify.rkt
@@ -24,60 +24,58 @@
     ; if s in alist, remove the old mapping and append the new mapping
     (cons `(,s ,new-sym) (remove entry alist))))
 
-(define (uniquify-exp alist)
-  (lambda (e)
-    (match e
-      ; Look up the symbol in the alist. If it exists, return the mapping in the alist.
-      ; Otherwise, throw an error because the symbol wasn't defined 
-      [(? symbol? s) (alist-get s alist)]
-      [(? integer?) e]
-      [`(let ([,var ,val]) ,body) 
-        ; uniquify val expr with old alist
-        (define uniquified-val ((uniquify-exp alist) val))
+;
+; TODO: purpose statement
+;
+(define (uniquify-exp e alist)
+  (match e
+    ; Look up the symbol in the alist. If it exists, return the mapping in the alist.
+    ; Otherwise, throw an error because the symbol wasn't defined 
+    [(? symbol? s) (alist-get s alist)]
+    [(? integer?) e]
+    [`(let ([,var ,val]) ,body) 
+     ; uniquify val expr with old alist
+     (define uniquified-val (uniquify-exp val alist))
 
-        ; update the alist to reflect the newly defined var
-        ; if it exists, update the mapping
-        (define new-alist (alist-update var alist))
+     ; update the alist to reflect the newly defined var
+     ; if it exists, update the mapping
+     (define new-alist (alist-update var alist))
+     
+     (define new-var (alist-get var new-alist))
+     
+     ; then evaluate the body with the updated alist
+     (define uniquified-body (uniquify-exp body new-alist))
+     
+     ; then return the whole uniquified let expr
+     `(let ([,new-var ,uniquified-val]) ,uniquified-body)]
+    [`(,op ,es ...)
+     `(,op ,@(for/list ([e es]) (uniquify-exp e alist)))]
+    [_ (error "Malformed expression given to uniquify-exp: ~s" e)]))
 
-        (define new-var (alist-get var new-alist))
-
-        ; then evaluate the body with the updated alist
-        (define uniquified-body ((uniquify-exp new-alist) body))
-
-        ; then return the whole uniquified let expr
-        `(let ([,new-var ,uniquified-val]) ,uniquified-body)]
-      [`(,op ,es ...)
-       `(,op ,@(for/list ([e es]) ((uniquify-exp alist) e)))]
-      [_ (error "Malformed expression given to uniquify-exp: ~s" e)])))
-
-(define uniquify
-  (lambda (e)
-    (match e
-      [`(program ,info (,label ,e))
-       `(program ,info (,label ,((uniquify-exp '()) e)))]
-      [_ (error "Malformed program given to uniquify: ~s" e)])))
-
-; tests for uniquify-exp
-(define uniquify-exp-func (uniquify-exp '()))
+(define (uniquify e)
+  (match e
+    [`(program ,info (,label ,e))
+     `(program ,info (,label ,((uniquify-exp '()) e)))]
+    [_ (error "Malformed program given to uniquify: ~s" e)]))
 
 (define given1 '(+ 2 2))
 (define expect1 '(+ 2 2))
-(check-equal? (uniquify-exp-func given1) expect1)
+(check-equal? (uniquify-exp given1 '()) expect1)
 
 ; renaming should work
 (define given2 '(let ([x 2]) (+ 2 x)))
-(check-match (uniquify-exp-func given2)
+(check-match (uniquify-exp given2 '())
               `(let ([,(? symbol? s) 2]) (+ 2 ,s)))
 
 (define given3 '(let ([x 1]) (let ([x x]) (+ x x))))
-(check-match (uniquify-exp-func given3)
+(check-match (uniquify-exp given3 '())
               `(let ([,(? symbol? s1) 1]) 
                  (let ([,(? symbol? s2) ,s1])
                    (+ ,s2 ,s2))))
 
 ; should fail since x is not defined
 (define given4 '(+ x 2))
-(check-fail (lambda () (uniquify-exp-func given4)))
+(check-fail (lambda () (uniquify-exp given4 '())))
 
 (define given5 '(let ([x 5]) (+ y 3)))
-(check-fail (lambda () (uniquify-exp-func given5)))
+(check-fail (lambda () (uniquify-exp given5 '())))


### PR DESCRIPTION
pull request in progress. do not merge

**Fixes #7** 

**CHANGES**

- [x] **uniquify.rkt** no longer accepts _`label`_
- [x] `uniquify-exp` is no longer a function that returns a function but rather simply a function that can be called because this simplifies testing and usage by the `compiler.rkt`
- [x] added new tests to **uniquify.rkt**
```racket
; test bad uniquify inputs
(check-fail (λ () (uniquify #t)))
(check-fail (λ () (uniquify uniquify-exp)))
; R1 does not have labels
(check-fail (λ () (uniquify '(program () (start (+ 2 2))))))


; TEST uniquify
(check-equal? (uniquify '(program () (+ 2 2)))
                '(program () (+ 2 2)))

(define given6expr '(let ([x 32]) (+ (let ([x 10]) x) x)))
(define given6 `(program () ,given6expr))
(check-match (uniquify given6)
             `(program () (let ([,x.1 32]) (+ (let ([,x.2 10]) ,x.2) ,x.1))))
```
- [x] **rco.rkt** no longer accepts _`label`_
- [x] added new tests to **rco.rkt** 
```racket
; test bad rco-prog inputs
(check-fail (λ () (rco-prog #t)))
(check-fail (λ () (rco-prog rco-prog)))
; R1 does not have labels
(check-fail (λ () (rco-prog '(program () (start (+ 2 2))))))


; TEST rco-prog simple 
(check-equal? (rco-prog '(program () (+ 2 2)))
                '(program () (+ 2 2)))

; TEST rco-prog complex
(check-match (rco-prog '(program () (+ (- 1) 2)))
                `(program () (let [[,(? symbol? tmp) (- 1)]] (+ ,tmp 2))))
```
- [x] **ec.rkt** no longer accepts _`label`_
- [x] added new tests to **ec.rkt** 